### PR TITLE
Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
## Summary
- add a 14-day cooldown for Dependabot updates to github-actions

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e6aaf5a6883269cd81e7dbc57ee7b)