### PR TITLE
Pin GitHub Actions to full-length SHAs

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
 
       - name: Enable auto-merge
         if: steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major'

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Build
         run: swift build --verbose


### PR DESCRIPTION
## Summary
- pin dependabot metadata action to a full-length commit SHA with version comment
- pin checkout action to a full-length commit SHA with version comment

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939c64821f08326b9f347fc20327f8b)